### PR TITLE
Running GitHub package installation first

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,12 @@ RUN apt-get --allow-releaseinfo-change update \
     r-cran-tidyverse \
     r-cran-devtools 
 
+# Install R packages on GitHub
+RUN R -e "devtools::install_github('achetverikov/apastats', subdir='apastats')"
+
 # Install R packages
 RUN install2.r --error \
     table1 \
     patchwork \
     kableExtra \
     papaja
-
-# Install R packages on GitHub
-RUN R -e "devtools::install_github('achetverikov/apastats', subdir='apastats')"


### PR DESCRIPTION
This PR places the installation of GitHub-hosted R package first, because it takes the most of the build time.
